### PR TITLE
Fix: Address analyzer errors and warnings from user feedback

### DIFF
--- a/pocket_biz_manager/lib/features/categories/providers/category_provider.dart
+++ b/pocket_biz_manager/lib/features/categories/providers/category_provider.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/foundation.dart';
-import '../models/category_model.dart';
+import '../models/category_model.dart' as model; // Use prefix 'model'
 import '../../../core/database/database_service.dart';
 
 class CategoryProvider with ChangeNotifier {
   final DatabaseService _dbService = DatabaseService.instance;
 
-  List<Category> _categories = [];
+  List<model.Category> _categories = []; // Use model.Category
   bool _isLoading = false;
 
-  List<Category> get categories => _categories;
+  List<model.Category> get categories => _categories; // Use model.Category
   bool get isLoading => _isLoading;
 
   CategoryProvider() {
@@ -19,7 +19,7 @@ class CategoryProvider with ChangeNotifier {
     _setLoading(true);
     try {
       final List<Map<String, dynamic>> maps = await _dbService.getAllCategories();
-      _categories = maps.map((map) => Category.fromMap(map)).toList();
+      _categories = maps.map((map) => model.Category.fromMap(map)).toList(); // Use model.Category
     } catch (e) {
       // Handle error, maybe log it or show a message to the user
       debugPrint("Error fetching categories: $e");
@@ -31,7 +31,7 @@ class CategoryProvider with ChangeNotifier {
   Future<bool> addCategory(String categoryName) async {
     _setLoading(true);
     try {
-      Category newCategory = Category(categoryName: categoryName.trim());
+      model.Category newCategory = model.Category(categoryName: categoryName.trim()); // Use model.Category
       // Check if category with the same name already exists (case-insensitive)
       bool exists = _categories.any((cat) => cat.categoryName.toLowerCase() == newCategory.categoryName.toLowerCase());
       if (exists) {
@@ -56,7 +56,7 @@ class CategoryProvider with ChangeNotifier {
     return false; // Indicate failure
   }
 
-  Future<bool> updateCategory(Category category) async {
+  Future<bool> updateCategory(model.Category category) async { // Use model.Category
     _setLoading(true);
     try {
       // Check if another category with the same name already exists (case-insensitive)
@@ -115,7 +115,7 @@ class CategoryProvider with ChangeNotifier {
     return false; // Indicate failure
   }
 
-  Category? getCategoryById(int id) {
+  model.Category? getCategoryById(int id) { // Use model.Category
     try {
       return _categories.firstWhere((cat) => cat.categoryID == id);
     } catch (e) {

--- a/pocket_biz_manager/lib/features/categories/screens/categories_screen.dart
+++ b/pocket_biz_manager/lib/features/categories/screens/categories_screen.dart
@@ -54,19 +54,23 @@ class _CategoriesScreenState extends State<CategoriesScreen> {
 
     if (confirmed == true) {
       final success = await provider.deleteCategory(category.categoryID!);
-      if (mounted) {
-          if (!success) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Failed to delete "${category.categoryName}". It might be in use or an error occurred.'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-          );
-        } else {
-           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Category "${category.categoryName}" deleted.'),
-              backgroundColor: Colors.green,
+      if (!mounted) return; // Check mounted before using context
+
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+      final theme = Theme.of(context);
+
+      if (!success) {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text('Failed to delete "${category.categoryName}". It might be in use or an error occurred.'),
+            backgroundColor: theme.colorScheme.error,
+          ),
+        );
+      } else {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text('Category "${category.categoryName}" deleted.'),
+            backgroundColor: Colors.green,
             ),
           );
         }

--- a/pocket_biz_manager/lib/features/payment_methods/screens/payment_methods_screen.dart
+++ b/pocket_biz_manager/lib/features/payment_methods/screens/payment_methods_screen.dart
@@ -46,19 +46,23 @@ class _PaymentMethodsScreenState extends State<PaymentMethodsScreen> {
 
     if (confirmed == true) {
       final success = await provider.deletePaymentMethod(method.paymentMethodID!);
-      if (mounted) {
-        if (!success) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Failed to delete "${method.methodName}". It might be in use or an error occurred.'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-          );
-        } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Payment method "${method.methodName}" deleted.'),
-              backgroundColor: Colors.green,
+      if (!mounted) return; // Check mounted before using context
+
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+      final theme = Theme.of(context);
+
+      if (!success) {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text('Failed to delete "${method.methodName}". It might be in use or an error occurred.'),
+            backgroundColor: theme.colorScheme.error,
+          ),
+        );
+      } else {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text('Payment method "${method.methodName}" deleted.'),
+            backgroundColor: Colors.green,
             ),
           );
         }

--- a/pocket_biz_manager/lib/features/products/screens/add_edit_product_screen.dart
+++ b/pocket_biz_manager/lib/features/products/screens/add_edit_product_screen.dart
@@ -160,7 +160,7 @@ class _AddEditProductScreenState extends State<AddEditProductScreen> {
                   border: const OutlineInputBorder(),
                   prefixIcon: Icon(Icons.category_outlined, color: Theme.of(context).inputDecorationTheme.labelStyle?.color),
                 ),
-                items: categoryProvider.categories.map<DropdownMenuItem<int>>((Category category) {
+                items: categoryProvider.categories.map<DropdownMenuItem<int>>((model.Category category) { // Explicitly use model.Category
                   return DropdownMenuItem<int>(
                     value: category.categoryID,
                     child: Text(category.categoryName),

--- a/pocket_biz_manager/lib/features/products/screens/products_screen.dart
+++ b/pocket_biz_manager/lib/features/products/screens/products_screen.dart
@@ -55,16 +55,24 @@ class _ProductsScreenState extends State<ProductsScreen> {
 
     if (confirmed == true) {
       final success = await provider.deleteProduct(product.productID!);
-      if (mounted) {
-        final message = success
-            ? 'Product "${product.productName}" deleted.'
-            : provider.errorMessage ?? 'Failed to delete "${product.productName}". It might be in use or an error occurred.';
-        final bgColor = success ? Colors.green : Theme.of(context).colorScheme.error;
+      if (!mounted) return; // Check mounted before using context
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(message), backgroundColor: bgColor),
-        );
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+      final theme = Theme.of(context);
+      final String message;
+      final Color bgColor;
+
+      if (success) {
+        message = 'Product "${product.productName}" deleted.';
+        bgColor = Colors.green;
+      } else {
+        message = provider.errorMessage ?? 'Failed to delete "${product.productName}". It might be in use or an error occurred.';
+        bgColor = theme.colorScheme.error;
       }
+
+      scaffoldMessenger.showSnackBar(
+        SnackBar(content: Text(message), backgroundColor: bgColor),
+      );
     }
   }
 

--- a/pocket_biz_manager/lib/main.dart
+++ b/pocket_biz_manager/lib/main.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'app/app_theme.dart';
-// Import other providers and screens later
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'app/app_theme.dart';
+import 'core/database/database_service.dart';
+import 'features/categories/providers/category_provider.dart';
+import 'features/payment_methods/providers/payment_method_provider.dart';
+import 'features/products/providers/product_provider.dart';
+import 'features/categories/screens/categories_screen.dart';
+import 'features/payment_methods/screens/payment_methods_screen.dart';
+import 'features/products/screens/products_screen.dart';
 
-import 'core/database/database_service.dart'; // Import DatabaseService
+// Import other providers and screens later // This line can be removed
 
 void main() async { // Made main async for potential async initializations
   // Ensure Flutter bindings are initialized
@@ -26,11 +35,11 @@ class MyApp extends StatelessWidget {
     // MultiProvider will be used to provide various services and state managers
     return MultiProvider(
       providers: [
-        // Example: ChangeNotifierProvider(create: (_) => ThemeNotifier()),
         ChangeNotifierProvider(create: (_) => CategoryProvider()),
         ChangeNotifierProvider(create: (_) => PaymentMethodProvider()),
-        ChangeNotifierProvider(create: (ctx) => ProductProvider()), // Add ProductProvider
-        // TODO: Add other providers for features here
+        ChangeNotifierProvider(create: (_) => ProductProvider()),
+        // TODO: Add other providers for features here (Example: ThemeNotifier if used)
+        // ChangeNotifierProvider(create: (_) => ThemeNotifier()),
       ],
       child: MaterialApp(
         title: 'PocketBiz Manager', // NAD Currency will be handled by intl
@@ -44,10 +53,6 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
-import 'features/categories/screens/categories_screen.dart';
-import 'features/payment_methods/screens/payment_methods_screen.dart';
-import 'features/products/screens/products_screen.dart'; // Import ProductsScreen
 
 // A temporary placeholder screen, modified to navigate to various management screens
 class PlaceholderScreen extends StatelessWidget {

--- a/pocket_biz_manager/pubspec.yaml
+++ b/pocket_biz_manager/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   sqflite: ^2.3.0
   path_provider: ^2.1.1
+  path: ^1.8.3 # Added path package
   intl: ^0.18.1
   provider: ^6.1.1
   # image_picker: ^1.0.4 # Add later


### PR DESCRIPTION
This commit resolves a batch of issues identified by the analyzer and user feedback:

1.  **Fix `ambiguous_import` for `Category`**: Used `as model` prefix for the custom category model in `category_provider.dart` to resolve name clash with Flutter's foundation `Category`.
2.  **Fix `directive_after_declaration` in `main.dart`**: Moved all import statements to the top of the file.
3.  **Fix `undefined_method` for Providers in `main.dart`**: Ensured correct `ChangeNotifierProvider(create: (_) => ...)` syntax.
4.  **Fix `argument_type_not_assignable` in `add_edit_product_screen.dart`**: Explicitly typed `model.Category` in DropdownButtonFormField's map function.
5.  **Fix `depend_on_referenced_packages` for `path`**: Added `path` package to `pubspec.yaml`.
6.  **Address `use_build_context_synchronously` warnings**: Improved handling of BuildContext across async gaps in screen files by checking `mounted` and capturing context-dependent objects locally.
7.  **Reviewed TODOs**: Existing TODOs were reviewed and deemed appropriate for future work.

These changes should improve code stability and correctness.